### PR TITLE
fix: compatibility version for img without src attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "mkdirp": "~0.3.5",
     "moment": "^2.9.0",
     "mustache": "~0.8.1",
-    "to-markdown": "0.0.1",
+    "to-markdown": "0.0.3",
     "xml2js": "~0.4.1",
     "yamljs": "^0.2.1"
   },


### PR DESCRIPTION
According to this issue : https://github.com/hexojs/hexo-migrator-wordpress/issues/1

Fixed by @domchristie and @danfinlay here : https://github.com/domchristie/to-markdown/pull/57

Version 0.0.3 allowing to parse wordpress xml export when image have no src attribute.